### PR TITLE
empty sub branch fails in crush tree

### DIFF
--- a/tools/ceph_osds_in_bucket.py
+++ b/tools/ceph_osds_in_bucket.py
@@ -42,6 +42,8 @@ def walk(node, bucket_type):
             child = nodes_by_id[child_id]
             children = children + walk(child, bucket_type)
         return children
+    else:  
+      	return []
 
 def list(bucket, type='osd'):
     global nodes_by_id


### PR DESCRIPTION
node walk will fail if there are children without  specified node bucket type.