### PR TITLE
Add time range feature and some other improvements

### DIFF
--- a/tools/ceph-gentle-reweight
+++ b/tools/ceph-gentle-reweight
@@ -6,13 +6,13 @@
 # Slowly drain a list of OSDs causing minimal impact in a ceph cluster.
 #
 
-import os, sys, getopt, commands, json, time
+import os, sys, getopt, commands, json, time, datetime
 
 def update_osd_tree():
   global osd_tree
   print "update_osd_tree: loading ceph osd tree"
   osd_tree_json = commands.getoutput('ceph osd tree --format=json 2>/dev/null')
-  osd_tree = json.loads(osd_tree_json) 
+  osd_tree = json.loads(osd_tree_json)
   print "update_osd_tree: done"
 
 def get_crush_weight(osd):
@@ -24,10 +24,26 @@ def get_crush_weight(osd):
       return weight
   raise Exception('Undefined crush_weight for %s' % osd)
 
+def in_timeframe(start_time, end_time, current_time, allowed_days, current_day):
+  print current_time.strftime('check current time: %H:%M:%S')
+  print "check current day: %s" % (current_day)
+  if current_day in allowed_days:
+    time_ok = True
+  elif start_time < end_time:
+    if current_time >= start_time and current_time <= end_time:
+      time_ok = True
+    else:
+      time_ok = False
+  elif current_time >= start_time or current_time <= end_time: #Over Midnight
+    time_ok = True
+  else:
+    time_ok = False
+  return time_ok
+
 def measure_latency(test_pool):
   print "measure_latency: measuring 4kB write latency"
   latency = commands.getoutput("rados -p %s bench 10 write -t 1 -b 4096 2>/dev/null | egrep -i 'average latency' | awk '{print $3}'" % test_pool)
-  latency_ms = 1000*float(latency) 
+  latency_ms = 1000*float(latency)
   print "measure_latency: current latency is %s" % latency_ms
   return latency_ms
 
@@ -50,11 +66,19 @@ def crush_reweight(osd, weight, really):
     return
   print "crush_reweight: not really doing it!"
 
-def reweight_osds(osds, max_pgs_backfilling, max_latency, delta_weight, target_weight, test_pool, interval, really):
+def reweight_osds(osds, max_pgs_backfilling, max_latency, delta_weight, target_weight, test_pool, start_time, end_time, allowed_days, interval, really):
   # check if there is any work to do:
   update_osd_tree()
 
   print "reweight_osds: changing all osds by weight %s (target %s)" % (delta_weight, target_weight)
+
+  # check timeframe
+  current_time = datetime.datetime.now().time()
+  current_day = datetime.datetime.now().weekday()
+  time_ok = in_timeframe(start_time, end_time, current_time, allowed_days, current_day)
+  if not time_ok:
+    print "current time: not within range %s - %s, trying again later" % (start_time, end_time)
+    return
 
   # check num pgs backfilling
   npgs = get_num_backfilling()
@@ -75,7 +99,7 @@ def reweight_osds(osds, max_pgs_backfilling, max_latency, delta_weight, target_w
     if delta_weight > 0 and weight >= (target_weight - delta_weight / 20):
       print "reweight_osds: skipping %s with weight %s target %s" % (osd, weight, target_weight)
       continue
-    
+
     if delta_weight < 0 and weight <= (target_weight - delta_weight / 20):
       print "reweight_osds: skipping %s with weight %s target %s" % (osd, weight, target_weight)
       continue
@@ -93,7 +117,7 @@ def reweight_osds(osds, max_pgs_backfilling, max_latency, delta_weight, target_w
     sys.exit(0)
 
 def usage(code=0):
-  print 'ceph-gentle-reweight -o <osd>[,<osd>,...] [-l <max_latency (default=20)>] [-b <max pgs backfilling (default=50)>] [-d <delta weight (default=0.01)>] [-t <target weight (default=2)>] [-p <latency test pool (default=test)>] [-i <interval (default=60)>]'
+  print 'ceph-gentle-reweight -o <osd>[,<osd>,...] [-l <max_latency (default=20)>] [-b <max pgs backfilling (default=50)>] [-d <delta weight (default=0.01)>] [-t <target weight (default=2)>] [-p <latency test pool (default=test)>] [-i <interval (default=60)>] [-s <start time (default=02:00)>] [-s <end time (defualt=09:00)>] [-a <day of week,[day of week,...]>]'
   sys.exit(code)
 
 def main(argv):
@@ -104,10 +128,13 @@ def main(argv):
   target_weight = 5.46
   test_pool = "test"
   interval = 60
+  start_time = "02:00"
+  end_time = "09:00"
+  allowed_days = []
   really = False
 
   try:
-    opts, args = getopt.getopt(argv,"ho:l:b:d:t:p:i:r",["osds=","latency=","backfills=","delta=","target=","pool=","interval=","really"])
+    opts, args = getopt.getopt(argv,"ho:l:b:d:t:p:i:s:e:a:r",["osds=","latency=","backfills=","delta=","target=","pool=","interval=","start_time=","end_time=","allowed_days=","really"])
   except getopt.GetoptError:
     usage(2)
   for opt, arg in opts:
@@ -127,11 +154,22 @@ def main(argv):
       test_pool = str(arg)
     elif opt in ("-i", "--interval"):
       interval = int(arg)
+    elif opt in ("-s", "--start-time"):
+      start_time = str(arg)
+    elif opt in ("-e", "--end-time"):
+      end_time = str(arg)
+    elif opt in ("-a", "--allowed-days"):
+      allowed_days = arg.split(',')
     elif opt in ("-r", "--really"):
       really = True
   if not drain_osds:
     usage(2)
- 
+
+  end_time = datetime.datetime.strptime(end_time, "%H:%M").time()
+  start_time = datetime.datetime.strptime(start_time, "%H:%M").time()
+  if allowed_days:
+    allowed_days = map(int, allowed_days)
+
   print 'Draining OSDs: ', drain_osds
   print 'Max latency (ms): ', max_latency
   print 'Max PGs backfilling: ', max_pgs_backfilling
@@ -139,11 +177,15 @@ def main(argv):
   print 'Target weight:', target_weight
   print 'Latency test pool:', test_pool
   print 'Run interval:', interval
+  print 'Start time:', start_time
+  print 'End time:', end_time
+  print 'Allowed days:', allowed_days
 
   while(True):
-    reweight_osds(drain_osds, max_pgs_backfilling, max_latency, delta_weight, target_weight, test_pool, interval, really)
+    reweight_osds(drain_osds, max_pgs_backfilling, max_latency, delta_weight, target_weight, test_pool, start_time, end_time, allowed_days, interval, really)
     print "main: sleeping %ss" % interval
     time.sleep(interval)
 
 if __name__ == "__main__":
   main(sys.argv[1:])
+

--- a/tools/split/ceph-gentle-split
+++ b/tools/split/ceph-gentle-split
@@ -6,7 +6,7 @@
 # Slowly split a pool causing minimal impact in a ceph cluster.
 #
 
-import sys, getopt, commands, json, time
+import sys, getopt, commands, json, time, datetime
 
 def update_osd_dump():
   global osd_dump
@@ -15,8 +15,8 @@ def update_osd_dump():
   if status:
     print "Error: %s", osd_dump_json
     sys.exit(1)
-  
-  osd_dump = json.loads(osd_dump_json) 
+
+  osd_dump = json.loads(osd_dump_json)
   print "update_osd_dump: done"
 
 def get_pg_num(pool_name):
@@ -39,10 +39,27 @@ def get_pgp_num(pool_name):
       return pgp_num
   raise Exception('Undefined pgp_num for %s' % pool_name)
 
-def measure_latency():
+def in_timeframe(start_time, end_time, current_time, allowed_days, current_day):
+  print current_time.strftime('check current time: %H:%M:%S')
+  print "check current day: %s" % (current_day)
+  if current_day in allowed_days:
+    time_ok = True
+  elif start_time < end_time:
+    if current_time >= start_time and current_time <= end_time:
+      time_ok = True
+    else:
+      time_ok = False
+  elif current_time >= start_time or current_time <= end_time: #Over Midnight
+    time_ok = True
+  else:
+    time_ok = False
+  return time_ok
+
+def measure_latency(test_pool):
   print "measure_latency: measuring 4kB write latency"
-  latency = commands.getoutput("rados -p test.os bench 10 write -t 1 -b 4096 2>/dev/null | egrep -i 'average latency' | awk '{print $3}'")
-  latency_ms = 1000*float(latency) 
+  cmd="rados -p %s bench 10 write -t 1 -b 4096 2>/dev/null | egrep -i 'average latency' | awk '{print $3}'" % (test_pool)
+  latency = commands.getoutput(cmd)
+  latency_ms = 1000*float(latency)
   print "measure_latency: current latency is %s" % latency_ms
   return latency_ms
 
@@ -60,26 +77,29 @@ def get_num_creating():
   print "get_num_creating: PGs currently creating: %s" % n
   return n
 
-def split_pool(pool, pg_num):
+def split_pool(pool, pg_num, really):
   cmd = "ceph osd pool set %s pg_num %s" % (pool, pg_num)
   print "split_pool: calling %s" % cmd
-  (status, out) = commands.getstatusoutput(cmd)
-  if status:
-    print "Error: %s", osd_dump_json
-    sys.exit(1)
-
-  print "split_pool: %s" % out
-  time.sleep(5)
-
-  cmd = "ceph osd pool set %s pgp_num %s" % (pool, pg_num)
-  status = 1
-  while status != 0:
-    print "split_pool: calling %s" % cmd
+  if really:
     (status, out) = commands.getstatusoutput(cmd)
-    print "split_pool: %s" % out
-    time.sleep(2)
+    if status:
+      print "Error: %s", osd_dump_json
+      sys.exit(1)
 
-def split(pool, goal, max_pgs_backfilling, max_latency, max_step):
+    print "split_pool: %s" % out
+    time.sleep(5)
+
+    cmd = "ceph osd pool set %s pgp_num %s" % (pool, pg_num)
+    status = 1
+    while status != 0:
+      print "split_pool: calling %s" % cmd
+      (status, out) = commands.getstatusoutput(cmd)
+      print "split_pool: %s" % out
+      time.sleep(2)
+    return
+  print "split_pool: not really doing it!"
+
+def split(pool, test_pool, goal, max_pgs_backfilling, max_latency, max_increment, start_time, end_time, allowed_days, really):
 
   # check if there is any work to do:
   update_osd_dump()
@@ -103,35 +123,47 @@ def split(pool, goal, max_pgs_backfilling, max_latency, max_step):
       print "split: npgs backfilling is too high, trying again later"
       return
 
+  # check timeframe
+  current_time = datetime.datetime.now().time()
+  current_day = datetime.datetime.now().weekday()
+  time_ok = in_timeframe(start_time, end_time, current_time, allowed_days, current_day)
+  if not time_ok:
+    print "current time: not within range %s - %s, trying again later" % (start_time, end_time)
+    return
+
   if max_latency > 0:
     # check the latency
-    latency = measure_latency()
+    latency = measure_latency(test_pool)
     if latency > max_latency:
       print "split: latency is too high, trying again later"
       return
 
-  new_pg_num = min(goal, current_pg_num + max_step)
+  new_pg_num = min(goal, current_pg_num + max_increment)
   print "split: %s new pg_num will be %s" % (pool, new_pg_num)
-  split_pool(pool, new_pg_num)
+  split_pool(pool, new_pg_num, really)
 
   if new_pg_num == goal:
     print "All done"
     sys.exit(0)
 
 def usage(code=0):
-  print 'ceph-gentle-split -p <pool> -g <goal num pgs> [-l <max_latency (default=50)>] [-b <max pgs backfilling (default=20)>] [-w <max step (default=10)>]'
+  print 'ceph-gentle-split -p <pool> [-t <latency-test-pool> (default=test)] -g <goal num pgs> [-l <max_latency (default=15)>] [-b <max pgs backfilling (default=10)>] [-s <start time (defualt=02:00)>] [-s <end time (defualt=09:00)>] [-a <day of week,[day of week,...] [-i <max increment (default=10)>]'
   sys.exit(code)
 
 def main(argv):
   pool = ''
+  test_pool = 'test'
   max_latency = 50
   max_pgs_backfilling = 20
-  max_step = 10
+  max_increment = 10
   goal = 0
-  
+  start_time = "02:00"
+  end_time = "09:00"
+  allowed_days = []
+  really = False
 
   try:
-    opts, args = getopt.getopt(argv,"hp:l:b:s:g:",["pool=","latency=","backfills=","step=","goal="])
+    opts, args = getopt.getopt(argv,"hp:t:l:b:s:g:i:a:e:r",["pool=","test_pool=","latency=","backfills=","increment=","goal=","allowed_days=","start_time=","end_time=","really"])
   except getopt.GetoptError:
     usage(2)
   for opt, arg in opts:
@@ -139,27 +171,47 @@ def main(argv):
       usage()
     elif opt in ("-p", "--pool"):
       pool = arg
+    elif opt in ("-t", "--test-pool"):
+      test_pool = arg
     elif opt in ("-l", "--latency"):
       max_latency = int(arg)
     elif opt in ("-b", "--backfills"):
       max_pgs_backfilling = int(arg)
-    elif opt in ("-s", "--step"):
-      max_step = int(arg)
+    elif opt in ("-i", "--increment"):
+      max_increment = int(arg)
     elif opt in ("-g", "--goal"):
       goal = int(arg)
+    elif opt in ("-s", "--start-time"):
+      start_time = str(arg)
+    elif opt in ("-e", "--end-time"):
+      end_time = str(arg)
+    elif opt in ("-a", "--allowed-days"):
+      allowed_days = arg.split(',')
+    elif opt in ("-r", "--really"):
+      really = True
   if not pool or goal < 1:
     usage(2)
- 
-  print 'Pool: ', pool
+
+  end_time = datetime.datetime.strptime(end_time, "%H:%M").time()
+  start_time = datetime.datetime.strptime(start_time, "%H:%M").time()
+  if allowed_days:
+    allowed_days = map(int, allowed_days)
+
+  print 'Pool:', pool
+  print 'Latency test pool:', test_pool
   print 'Goal: ', goal
-  print 'Max latency (ms): ', max_latency
-  print 'Max PGs backfilling: ', max_pgs_backfilling
-  print 'Max step:', max_step
+  print 'Max latency (ms):', max_latency
+  print 'Max PGs backfilling:', max_pgs_backfilling
+  print 'Max increment:', max_increment
+  print 'Start time:', start_time
+  print 'End time:', end_time
+  print 'Allowed days:', allowed_days
 
   while(True):
-    split(pool, goal, max_pgs_backfilling, max_latency, max_step)
+    split(pool, test_pool, goal, max_pgs_backfilling, max_latency, max_increment, start_time, end_time, allowed_days, really)
     print "main: sleeping 60s"
     time.sleep(60)
 
 if __name__ == "__main__":
   main(sys.argv[1:])
+


### PR DESCRIPTION
This change allows you to specify a time range in which the script is allowed to make changes. On each run the script will check if the current time falls within the allowed range, if not the script will sleep. 

In addition, you can specify day(s) of the week which are exempt from the range. For example, you might want the script to run all day on Saturday and Sunday but only at night during the rest of the week.

I've added the --really flag to the ceph-gentle-slit script. The script will not make any changes unless this flag is passed. It will only display the commands it would run.

Finally I've added an option to the ceph-gentle-split script to specify the pool to use for latency testing.