### PR TITLE
we take time to reweight osds one by one

### DIFF
--- a/tools/ceph-gentle-reweight
+++ b/tools/ceph-gentle-reweight
@@ -110,6 +110,7 @@ def reweight_osds(osds, max_pgs_backfilling, max_latency, delta_weight, target_w
       new_weight = max(max(weight + delta_weight, target_weight), 0)
     print "reweight_osds: %s new weight will be %s" % (osd, new_weight)
     crush_reweight(osd, new_weight, really)
+    time.sleep(30)
     changed = True
 
   if not changed:


### PR DESCRIPTION
Sleep for some time before weighting the next osd, so that we dont have too many re-map/peering in a sudden.