### PR TITLE
print all upmap commands each run

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -114,8 +114,8 @@ for pg in upmaps:
 # handle each remapped pg
 num_changed = 0
 for pg in remapped:
-  if num_changed >= 50:
-    break
+  if num_changed % 50 == 0:
+    print('wait')
 
   pgid = pg['pgid']
 
@@ -142,3 +142,5 @@ for pg in remapped:
     sys.exit(1)
   upmap_pg_items(pgid, pairs)
   num_changed += 1
+
+print('wait')

--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -115,7 +115,7 @@ for pg in upmaps:
 num_changed = 0
 for pg in remapped:
   if num_changed % 50 == 0:
-    print('wait')
+    print('wait; sleep 4; while ceph status | grep -q "peering\|activating"; do sleep 2; done')
 
   pgid = pg['pgid']
 
@@ -143,4 +143,4 @@ for pg in remapped:
   upmap_pg_items(pgid, pairs)
   num_changed += 1
 
-print('wait')
+print('wait; sleep 4; while ceph status | grep -q "peering\|activating"; do sleep 2; done')


### PR DESCRIPTION
Printing just 50 commands at a time can be very time intensive with thousands of PGs to modofiy, however executing too many commands at once will cause segfaults.  Adding in a BASH `wait` into the output every 50 commands will satisfy both needs.