### PR TITLE
Re-add a status check before executing commands

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -112,6 +112,7 @@ for pg in upmaps:
    has_upmap[pgid] = True
 
 # handle each remapped pg
+print('while ceph status | grep -q "peering\|activating"; do sleep 2; done')
 num_changed = 0
 for pg in remapped:
   pgid = pg['pgid']


### PR DESCRIPTION
The reason for placing the sleep + status check at the beginning was a simple way to ensure we ran a status check before we start adding to any peering with the first block of upmap commands.  This is a more elegant way to add the check back without the sleep or useless wait.