### PR TITLE
convert lists to sets so we can subtract them

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -54,8 +54,8 @@ def valid_osds(osds):
   return valid
 
 def gen_upmap_replicated(up, acting):
-  u = valid_osds(set(up))
-  a = valid_osds(set(acting))
+  u = set(valid_osds(up))
+  a = set(valid_osds(acting))
   assert(len(u) == len(a))
   lhs = u - a
   rhs = a - u


### PR DESCRIPTION
The "u -a" and "a - u" statements in lines 60 and 61 are only allowed on sets, so these commands fail. Due to the 'try... except continue' construction (lines 139 upto 142) this is not obvious to the user. This small fix converts the lists to sets before substracting.
