### PR TITLE
Add up PGs with status backfilling and backfill_wait. Fixes #22

### DIFF
--- a/tools/ceph-gentle-reweight
+++ b/tools/ceph-gentle-reweight
@@ -49,8 +49,8 @@ def measure_latency(test_pool):
 
 def get_num_backfilling():
   n = 0
+  cmd = "ceph pg stat | tr ',:' '\n' | awk '/%s/ { total += $1}; END { print total}'"
   for status in ['backfilling', 'backfill_wait']:
-    cmd = "ceph pg stat | tr ',:' '\n' | awk '/%s/ { total += $1}; END { print total}'"
     out = commands.getoutput(cmd % status)
     if out:
       n += int(out)

--- a/tools/ceph-gentle-reweight
+++ b/tools/ceph-gentle-reweight
@@ -48,12 +48,12 @@ def measure_latency(test_pool):
   return latency_ms
 
 def get_num_backfilling():
-  cmd = "ceph pg stat | tr ',:' '\n' | awk '/backfilling/ { total += $1}; END { print total}'"
-  out = commands.getoutput(cmd)
-  if not out:
-    n = 0
-  else:
-    n = int(out)
+  n = 0
+  for status in ['backfilling', 'backfill_wait']:
+    cmd = "ceph pg stat | tr ',:' '\n' | awk '/%s/ { total += $1}; END { print total}'"
+    out = commands.getoutput(cmd % status)
+    if out:
+      n += int(out)
   print "get_num_backfilling: PGs currently backfilling: %s" % n
   return n
 


### PR DESCRIPTION
This will also take the status `backfill_wait` into account, so the script stops increasing weights when `osd_max_backfills` is not high enough.