### PR TITLE
upmap-remapped.py nautilus fix

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -87,7 +87,11 @@ def rm_upmap_pg_items(pgid):
 # discover remapped pgs
 try:
   remapped_json = commands.getoutput('ceph pg ls remapped -f json')
-  remapped = json.loads(remapped_json)
+  try:
+# Nautilus added a new tier to the json output
+    remapped = json.loads(remapped_json)['pg_stats']
+  except:
+    remapped = json.loads(remapped_json)
 except ValueError:
   eprint('Error loading remapped pgs')
   sys.exit(1)

--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -35,11 +35,11 @@
 # Hacked by: Dan van der Ster <daniel.vanderster@cern.ch>
 
 from __future__ import print_function
-import json, commands, sys
+import json, subprocess, sys
 
 try:
-  OSDS = commands.getoutput('ceph osd ls -f json')
-except ValueError:
+  OSDS = subprocess.check_output(['ceph', 'osd', 'ls', '-f', 'json'])
+except:
   eprint('Error loading OSD IDs')
   sys.exit(1)
 
@@ -86,7 +86,7 @@ def rm_upmap_pg_items(pgid):
 
 # discover remapped pgs
 try:
-  remapped_json = commands.getoutput('ceph pg ls remapped -f json')
+  remapped_json = subprocess.check_output(['ceph', 'pg', 'ls', 'remapped', '-f', 'json'])
   remapped = json.loads(remapped_json)
 # nautilus added a new tier to the json output
   if 'pg_ready' in remapped:
@@ -94,19 +94,23 @@ try:
       remapped = json.loads(remapped_json)['pg_stats']
     else:
       raise ValueError
-except ValueError:
+except:
   eprint('Error loading remapped pgs')
   sys.exit(1)
 
 # discover existing upmaps
-osd_dump_json = commands.getoutput('ceph osd dump -f json')
-osd_dump = json.loads(osd_dump_json)
-upmaps = osd_dump['pg_upmap_items']
+try:
+  osd_dump_json = subprocess.check_output(['ceph', 'osd', 'dump', '-f', 'json'])
+  osd_dump = json.loads(osd_dump_json)
+  upmaps = osd_dump['pg_upmap_items']
+except:
+  eprint('Error loading pg_upmap_items')
+  sys.exit(1)
 
 # discover pools replicated or erasure
 pool_type = {}
 try:
-  for line in commands.getoutput('ceph osd pool ls detail').split('\n'):
+  for line in subprocess.check_output(['ceph', 'osd', 'pool', 'ls', 'detail']).split('\n'):
     if 'pool' in line:
       x = line.split(' ')
       pool_type[x[1]] = x[3]

--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -87,11 +87,13 @@ def rm_upmap_pg_items(pgid):
 # discover remapped pgs
 try:
   remapped_json = commands.getoutput('ceph pg ls remapped -f json')
-  try:
-# Nautilus added a new tier to the json output
-    remapped = json.loads(remapped_json)['pg_stats']
-  except:
-    remapped = json.loads(remapped_json)
+  remapped = json.loads(remapped_json)
+# nautilus added a new tier to the json output
+  if 'pg_ready' in remapped:
+    if 'pg_stats' in remapped:
+      remapped = json.loads(remapped_json)['pg_stats']
+    else:
+      raise ValueError
 except ValueError:
   eprint('Error loading remapped pgs')
   sys.exit(1)


### PR DESCRIPTION
`pg_ready` and `pg_stats` are new tiers in the json output of `ceph pg ls remapped -f json` in nautilus. `pg_ready` is always there while `pg_stats` is only there if there are any remapped pgs.

This logic will allow this script to work in nautilus clusters while also defaulting to the same `except` output if no pgs are in the remapped state.

--------

I also ran into an issue on a system with python3 as the default so I swapped out `commands` for `subprocess`. `commands` was deprecated in python 2.6 and removed in python 3.

I removed most explicit `except` catches to just catch everything since the exception thrown by `subprocess` is different than that of `commands`.