### PR TITLE
move eprint definition

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -37,15 +37,15 @@
 
 import json, subprocess, sys
 
+def eprint(*args, **kwargs):
+  print(*args, file=sys.stderr, **kwargs)
+
 try:
   OSDS = json.loads(subprocess.getoutput('ceph osd ls -f json'))
   DF = json.loads(subprocess.getoutput('ceph osd df -f json | jq .nodes'))
 except ValueError:
   eprint('Error loading OSD IDs')
   sys.exit(1)
-
-def eprint(*args, **kwargs):
-  print(*args, file=sys.stderr, **kwargs)
 
 def crush_weight(id):
   for o in DF:


### PR DESCRIPTION
eprint was being called before it was defined.

Howdy Dan,
I just came across a cluster issue that this script was perfect for. Apparently when I added that `try` a few years ago I forgot to move the eprint definition above it.