### PR TITLE
upmap: Add basic/empty filter to jq and fix Python string/JSON issue

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -44,7 +44,7 @@ def eprint(*args, **kwargs):
   print(*args, file=sys.stderr, **kwargs)
 
 try:
-  OSDS = json.loads(subprocess.getoutput('ceph osd ls -f json | jq -r'))
+  OSDS = json.loads(subprocess.getoutput('ceph osd ls -f json | jq -r .'))
   DF = json.loads(subprocess.getoutput('ceph osd df -f json | jq -r .nodes'))
 except ValueError:
   eprint('Error loading OSD IDs')
@@ -93,7 +93,7 @@ def rm_upmap_pg_items(pgid):
 
 # discover remapped pgs
 try:
-  remapped_json = subprocess.getoutput('ceph pg ls remapped -f json | jq -r')
+  remapped_json = r'{}'.format(subprocess.getoutput('ceph pg ls remapped -f json | jq -r .'))
   remapped = json.loads(remapped_json)
 except ValueError:
   eprint('Error loading remapped pgs')
@@ -108,7 +108,7 @@ except KeyError:
   sys.exit(0)
 
 # discover existing upmaps
-osd_dump_json = subprocess.getoutput('ceph osd dump -f json | jq -r')
+osd_dump_json = subprocess.getoutput('ceph osd dump -f json | jq -r .')
 osd_dump = json.loads(osd_dump_json)
 upmaps = osd_dump['pg_upmap_items']
 


### PR DESCRIPTION
Hello everyone!

First and foremost, I would like to thank you for creating this script - it's incredibly helpful in my daily work!

A few months ago, I started having issues with the `upmap-remapped.py` script (on Ubuntus 16.04 - 20.04, Cephs 14-16).

I quickly discovered that the issue occurred due to the recently added `jq` filtering. According to the `jq` manual, it requires a filter, and the basic/empty filter is just a dot `.`. The fix was trivial: adding a dot `.` filter to all `jq` commands resolved the issue, and the script started working again.

A few tries/weeks later, I encountered another issue - Python was complaining that the JSON string wasn't correct and couldn't be decoded. I was surprised because the string had gone through `jq`, so it should have been correct. This issue occurred some time ago, so I can't provide all the details, but it was related to some special characters or sequence in the JSON string from `ceph pg ls remapped` that was parsed by Python. I'm certain it was related to the issue described here: https://discuss.python.org/t/help-json-loads-cannot-parse-valid-json/12605
But getting back to the point I fixed the Python string/JSON issue by converting the subprocess output to a "raw string" which was then correctly decoded by the JSON interpreter/decoder.