### PR TITLE
Fix to ignore unquoted strings

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -108,7 +108,7 @@ except KeyError:
   sys.exit(0)
 
 # discover existing upmaps
-osd_dump_json = subprocess.getoutput('ceph osd dump -f json | jq -r')
+osd_dump_json = subprocess.getoutput('ceph osd dump -f json | jq -r \'walk(if type == "object" then del(.score_acting, .score_stable) else . end)\'')
 osd_dump = json.loads(osd_dump_json)
 upmaps = osd_dump['pg_upmap_items']
 


### PR DESCRIPTION
The script was throwing the following error:

```
[root@naret-monitor01 ~]# ./upmap-remapped.py
Traceback (most recent call last):
 File "./upmap-remapped.py", line 112, in <module>
   osd_dump = json.loads(osd_dump_json)
 File "/usr/lib64/python3.6/json/__init__.py", line 354, in loads
   return _default_decoder.decode(s)
 File "/usr/lib64/python3.6/json/decoder.py", line 339, in decode
   obj, end = self.raw_decode(s, idx=_w(s, 0).end())
 File "/usr/lib64/python3.6/json/decoder.py", line 357, in raw_decode
   raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 105 column 25 (char 3099)
```

The output of `ceph osd dump -f json | jq -r` contained two lines with unquoted strings. 

```
        "score_acting": DBL_MAX,
        "score_stable": DBL_MAX,
```

As these lines should not be relevant for the script purpose, this change will delete them to allow the correct parsing of the JSON.