### PR TITLE
tools/upmap: turn string with escape chars into raw string literals

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -188,11 +188,11 @@ for pg in upmaps:
   has_upmap[pgid] = True
 
 # handle each remapped pg
-print('while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
+print(r'while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
 num = 0
 for pg in remapped:
   if num == 50:
-    print('wait; sleep 4; while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
+    print(r'wait; sleep 4; while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
     num = 0
 
   if ignore_backfilling:
@@ -228,5 +228,5 @@ for pg in remapped:
   upmap_pg_items(pgid, pairs)
   num += 1
 
-print('wait; sleep 4; while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
+print(r'wait; sleep 4; while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
 cluster.shutdown()


### PR DESCRIPTION
```
 $ ./upmap.py
/root/./upmap.py:191: SyntaxWarning: invalid escape sequence '\|'
  print('while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
/root/./upmap.py:195: SyntaxWarning: invalid escape sequence '\|'
  print('wait; sleep 4; while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
/root/./upmap.py:231: SyntaxWarning: invalid escape sequence '\|'
  print('wait; sleep 4; while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
There are no remapped PGs

 python3 --version
Python 3.13.2
```
looks to be a python 3.12 beyond syntax warning popping up:
https://stackoverflow.com/questions/77531208/python-3-12-syntaxwarning-invalid-escape-sequence-on-triple-quoted-string-d