### PR TITLE
Do not perform rados client shutdown in shell mode

### DIFF
--- a/tools/upmap/upmap-remapped.py
+++ b/tools/upmap/upmap-remapped.py
@@ -233,4 +233,6 @@ for pg in remapped:
   num += 1
 
 print(r'wait; sleep 4; while ceph status | grep -q "peering\|activating\|laggy"; do sleep 2; done')
-cluster.shutdown()
+
+if not use_shell:
+  cluster.shutdown()


### PR DESCRIPTION
PR #42 changed the upmap-remapped.py script behavior to prefer librados Python bindings if available over direct shell commands. The very last step in the script is a call to `cluster.shutdown()` for the rados client instance, but it is performed unconditionally even in shell mode, causing the script to emit a `NameError` for `cluster`.

This PR addresses the issue by guarding the `cluster.shutdown()` call so that it happens only when the script is using librados.